### PR TITLE
Fix gsettings Gnome Shell schema lookup

### DIFF
--- a/connector/chrome-gnome-shell.py
+++ b/connector/chrome-gnome-shell.py
@@ -357,7 +357,7 @@ class ChromeGNOMEShell(Gio.Application):
             source = Gio.SettingsSchemaSource.get_default()
             shell_version = self.shell_proxy.get_cached_property("ShellVersion")
 
-            if source.lookup(SHELL_SCHEMA, False) is not None and shell_version is not None:
+            if source.lookup(SHELL_SCHEMA, True) is not None and shell_version is not None:
                 settings = Gio.Settings.new(SHELL_SCHEMA)
 
                 if EXTENSION_DISABLE_VERSION_CHECK_KEY in settings.keys():


### PR DESCRIPTION
In lookup, recurse through the returned schema sources from
Gio.SettingsSchemaSource.get_default as suggested by
https://people.gnome.org/~gcampagna/docs/Gio-2.0/Gio.SettingsSchemaSource.get_default.html

This fixes Gnome Shell gsettings schema detection.


---

Firefox fails with:
> no_gnome_shell

I fixed this locally by switching Gio SettingsSchemaSource lookup recurse parameter to True per:
[Gio SettingsSchemaSource get_default comment](https://people.gnome.org/~gcampagna/docs/Gio-2.0/Gio.SettingsSchemaSource.get_default.html)
telling:

> The returned source may actually consist of multiple schema sources from different directories, depending on which directories were given in `XDG_DATA_DIRS` and `GSETTINGS_SCHEMA_DIR`. For this reason, all lookups performed against the default source should probably be done recursively.