### PR TITLE
extension: added charset

### DIFF
--- a/extension/extension.html
+++ b/extension/extension.html
@@ -5,7 +5,10 @@
 	http://forums.opera.com/discussion/1874611/bugpublication-extension-manifest-broken-after-extension-publicated
 -->
 <html>
-	<head><title>.</title></head>
+	<head>
+		<meta charset="utf-8" />
+		<title>.</title>
+	</head>
 	<body>
 		<script src="include/external/jquery-2.1.4.js"></script>
 		<script src="include/i18n.js"></script>


### PR DESCRIPTION
Define charset to remove this error (in Firefox):

> L’encodage de caractères du document HTML n’a pas été déclaré. Le document sera affiché avec des caractères incorrects pour certaines configurations de navigateur si le document contient des caractères en dehors de la plage US-ASCII. L’encodage de caractères de la page doit être déclaré dans le document ou dans le protocole de transfert.